### PR TITLE
[WIP] Use GitHub Actions to build Docker image & GitHub Packages to host the image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,28 @@
+name: Publish Docker image to GitHub Package Registry
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    steps:
+
+    - name: Copy Repo Files
+      uses: actions/checkout@master
+
+    - name: Publish Docker Image to GPR
+      uses: machine-learning-apps/gpr-docker-publish@master
+      with:
+        IMAGE_NAME: 'python3'
+        DOCKERFILE_PATH: 'docker/python3/Dockerfile'
+        BUILD_CONTEXT: 'docker/python3/'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # This second step is illustrative and shows how to reference the 
+    # output variables.  This is completely optional.
+    - name: Show outputs of previous step
+      run: |
+        echo "The name:tag of the Docker Image is: $VAR1"
+        echo "The docker image is hosted at $VAR2"
+      env:
+        VAR1: ${{ steps.docker.outputs.IMAGE_SHA_NAME }}
+        VAR2: ${{ steps.docker.outputs.IMAGE_URL }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,14 +11,13 @@ jobs:
     - name: Publish Docker Image to GPR
       uses: machine-learning-apps/gpr-docker-publish@master
       with:
-        IMAGE_NAME: 'python3'
-        DOCKERFILE_PATH: 'docker/python3/Dockerfile'
-        BUILD_CONTEXT: 'docker/python3/'
+        image_name: 'python3'
+        dockerfile_path: 'docker/python3/Dockerfile'
+        build_context: 'docker/python3/'
+        cache: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # This second step is illustrative and shows how to reference the 
-    # output variables.  This is completely optional.
     - name: Show outputs of previous step
       run: |
         echo "The name:tag of the Docker Image is: $VAR1"

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.4.3-slim
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential libblas-dev liblapack-dev gfortran
+RUN pip install numpy==1.8.2
+RUN pip install scipy==0.13.3
+
+CMD ["python"]


### PR DESCRIPTION
To pull the docker image which hosted on GitHub Packages, we need GitHub authentication information.
I think this is bad UX. So I'm using Docker Hub now.
But if the feature was fixed, I think GitHub Packages is better place to host the Docker images.

[1] https://qiita.com/yoichiwo7/items/dcea47782a5189d1c1c9
[2] https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782/
