### PR TITLE
Enable to use acd languages before running acd config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,7 +97,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
-	if err != nil && !isConfigCommand(os.Args) {
+	if err != nil && !isConfigCommand(os.Args) && !isLanguagesCommand(os.Args) {
 		fmt.Println(err)
 		fmt.Println("Please run `acd config`.")
 		os.Exit(1)
@@ -114,3 +114,12 @@ func isConfigCommand(args []string) bool {
 	return false
 }
 
+func isLanguagesCommand(args []string) bool {
+	for _, arg := range args {
+		if arg == "languages" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
# Summary
With this change, you can use `acd languages` to see the list of supported languages ​​before/when you first create the configuration file.